### PR TITLE
Fix handler not working on <button> elements and breaking after first…

### DIFF
--- a/app/javascript/application/sweet-alert-confirm.js
+++ b/app/javascript/application/sweet-alert-confirm.js
@@ -4,8 +4,10 @@ import sweetAlert from 'sweetalert2/dist/sweetalert2.all'
 const confirmed = (element, result) => {
   if (result.value) {
     // User clicked confirm button
-    element.removeAttribute('data-confirm-swal')
-    element.click()
+    const currentSwalDataAttribute = element.getAttribute('data-confirm-swal');
+    element.removeAttribute('data-confirm-swal');
+    element.click();
+    element.setAttribute('data-confirm-swal', currentSwalDataAttribute);
   }
 }
 
@@ -39,5 +41,5 @@ function handleConfirm(element) {
   }
 }
 
-Rails.delegate(document, 'a[data-confirm-swal]', 'click', handleConfirm)
+Rails.delegate(document, '[data-confirm-swal]', 'click', handleConfirm)
 


### PR DESCRIPTION
… click

2 changes:

1) The handler was filter only `a` elements with `data-confirm-swal` attributes. It's very common to use `data-confirm` attributes in `button` elements (for instance, on submitting forms, so I removed the `a` restriction, activating the handler on any element that has `data-confirm-swal`. 

2) If you have a button that is meant to be clicked more than once, the previous code didn't work. Imagine, for instance, a "delete all" button, that stays fixed in the UI, and when confirmed a partial is updated via ajax .. since the script removed the `data-confirm-swal` after the first click, from the second click onwards the SweetAlert wouldn't be triggered. This pull request stores the previous `data-confirm-swal` in a temp variable, clicks the button (so the infinite Swal loop is avoided), and then (and only then) restaures the sweet alert behavior, so it keeps working for other clicks.